### PR TITLE
Use static binary in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,12 @@
-FROM golang:1.5-onbuild
+FROM alpine:latest
 
-# onbuild handles all teh things
+ENV VERSION 1.1.0
+ENV ARCH amd64
+
+ADD https://github.com/CWSpear/local-persist/releases/download/v${VERSION}/local-persist-linux-${ARCH} /usr/bin/docker-volume-local-persist
+RUN chmod +x /usr/bin/docker-volume-local-persist
+
+ADD https://github.com/Yelp/dumb-init/releases/download/v1.0.3/dumb-init_1.0.3_amd64 /usr/bin/dumb-init
+RUN chmod +x /usr/bin/dumb-init
+
+CMD ["dumb-init", "/usr/bin/docker-volume-local-persist"]


### PR DESCRIPTION
This pull request changes the dockerfile such that it uses the released static binary, instead of the go build. Reduces the container size from ~757 MB to ~22 MB by using alpine as the base. This results in much faster pull times, and less hard disk usage.